### PR TITLE
Allow array properties as page parameters

### DIFF
--- a/Twig/PagerfantaExtension.php
+++ b/Twig/PagerfantaExtension.php
@@ -12,6 +12,7 @@
 namespace WhiteOctober\PagerfantaBundle\Twig;
 
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\Form\Util\PropertyPath;
 use Pagerfanta\PagerfantaInterface;
 
 /**
@@ -74,11 +75,12 @@ class PagerfantaExtension extends \Twig_Extension
             }
         }
 
-        $routeName     = $options['routeName'];
-        $routeParams   = $options['routeParams'];
-        $pageParameter = $options['pageParameter'];
-        $routeGenerator = function($page) use($router, $routeName, $routeParams, $pageParameter) {
-            return $router->generate($routeName, array_merge($routeParams, array($pageParameter => $page)));
+        $routeName        = $options['routeName'];
+        $routeParams      = $options['routeParams'];
+        $pagePropertyPath = new PropertyPath($options['pageParameter']);
+        $routeGenerator = function($page) use($router, $routeName, $routeParams, $pagePropertyPath) {
+            $pagePropertyPath->setValue($routeParams, $page);
+            return $router->generate($routeName, $routeParams);
         };
 
         return $this->container->get('white_october_pagerfanta.view_factory')->get($viewName)->render($pagerfanta, $routeGenerator, $options);


### PR DESCRIPTION
This change allows array properties as page parameter passed to the twig helper:

```
{{ pagerfanta(pager, 'default', {'pageParameter': 'foo[bar][page]'}) }}
```
