### PR TITLE
Added support for the Portuguese locale.

### DIFF
--- a/Resources/translations/pagerfanta.pt.xliff
+++ b/Resources/translations/pagerfanta.pt.xliff
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="pt" target-language="pt" datatype="plaintext" original="file.ext">
+        <body>
+            <trans-unit id="1">
+                <source>previous</source>
+                <target>Anterior</target>
+            </trans-unit>
+            <trans-unit id="2">
+                <source>next</source>
+                <target>Próxima</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>


### PR DESCRIPTION
This commit adds support for the Portuguese locale. I've only used the language code, even though we have some differences between pt_PT and pt_BR, due to the fact that the words used on the xliff have the same meaning across all Portuguese speaking countries.

If/when the need arises for a separated xliff file for each country, then I'll gladly work on it. =)
