### PR TITLE
Updated the composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,11 +11,16 @@
         }
     ],
     "require": {
-        "symfony/framework-bundle": "2.*",
-        "pagerfanta/pagerfanta": "dev-master"
+        "symfony/framework-bundle": "~2.1",
+        "pagerfanta/pagerfanta": "1.0.*"
     },
     "autoload": {
         "psr-0": { "WhiteOctober\\PagerfantaBundle": "" }
     },
-    "target-dir": "WhiteOctober/PagerfantaBundle"
+    "target-dir": "WhiteOctober/PagerfantaBundle",
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.0.x-dev"
+        }
+    }
 }


### PR DESCRIPTION
- Added the branch alias for the master branch
- Fixed the minimum requirement for FrameworkBundle as 2.0 should use the older branch
- Changed the Pagerfanta constraint to a range to allow stable versions for future releases (requires https://github.com/whiteoctober/Pagerfanta/pull/74 to be merged first)
