### PR TITLE
Stable version 1.0.* of pagerfanta does not exist

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "symfony/framework-bundle": "~2.1",
-        "pagerfanta/pagerfanta": "1.0.*"
+        "pagerfanta/pagerfanta": "1.0.*@dev"
     },
     "autoload": {
         "psr-0": { "WhiteOctober\\PagerfantaBundle": "" }


### PR DESCRIPTION
``` cmd
➜  WhiteOctoberPagerfantaBundle git:(master) composer.phar install --dev --prefer-dist
Loading composer repositories with package information
Installing dependencies
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - The requested package pagerfanta/pagerfanta could not be found in any version, there may be a typo in the package name.

Potential causes:
 - A typo in the package name
 - The package is not available in a stable-enough version according to your minimum-stability setting
   see <https://groups.google.com/d/topic/composer-dev/_g3ASeIFlrc/discussion> for more details.

Read <http://getcomposer.org/doc/articles/troubleshooting.md> for further common problems.
```
