### PR TITLE
Fixed the branch alias for master

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "target-dir": "WhiteOctober/PagerfantaBundle",
     "extra": {
         "branch-alias": {
-            "dev-master": "1.0.x-dev"
+            "dev-master": "2.2.x-dev"
         }
     }
 }


### PR DESCRIPTION
You created a 2.1 branch for Symfony 2.1 instead of starting the versionning of the bundle at 1. so the alias for the master branch has to be higher than 2.1.

note however that this 2.1 branch is useless: the PropertyAccess 2.2 component can be used in a symfony 2.1 project (it simply requires requiring it properly)
