### PR TITLE
Rename 'prev_message' parameter in TwitterBootstrapTranslatedView to 'previous_message'

### DIFF
--- a/View/TwitterBootstrapTranslatedView.php
+++ b/View/TwitterBootstrapTranslatedView.php
@@ -43,8 +43,8 @@ class TwitterBootstrapTranslatedView implements ViewInterface
      */
     public function render(PagerfantaInterface $pagerfanta, $routeGenerator, array $options = array())
     {
-        if (!isset($options['prev_message'])) {
-            $options['prev_message'] = '&larr; '.$this->translator->trans('previous', array(), 'pagerfanta');
+        if (!isset($options['previous_message'])) {
+            $options['previous_message'] = '&larr; '.$this->translator->trans('previous', array(), 'pagerfanta');
         }
         if (!isset($options['next_message'])) {
             $options['next_message'] = $this->translator->trans('next', array(), 'pagerfanta').' &rarr;';


### PR DESCRIPTION
DefaultTranslatedView and the documentation (README.md) both use 'previous_message'. The different spelling ('prev' => 'previous') can be easily overlooked.

This PR depends on [Pagerfanta PR #140](https://github.com/whiteoctober/Pagerfanta/pull/104).
