### PR TITLE
Add "routeGenerator" option to pagerfanta Twig extension

### DIFF
--- a/Twig/PagerfantaExtension.php
+++ b/Twig/PagerfantaExtension.php
@@ -52,41 +52,48 @@ class PagerfantaExtension extends \Twig_Extension
      * @param string              $viewName   The view name.
      * @param array               $options    An array of options (optional).
      *
-     * @return string The pagerfanta rendered.
+     * @throws \Exception
+     * @return string     The pagerfanta rendered.
      */
     public function renderPagerfanta(PagerfantaInterface $pagerfanta, $viewName = null, array $options = array())
     {
         $options = array_replace(array(
-            'routeName'     => null,
-            'routeParams'   => array(),
-            'pageParameter' => '[page]',
+            'routeGenerator' => null,
+            'routeName'      => null,
+            'routeParams'    => array(),
+            'pageParameter'  => '[page]',
         ), $options);
 
         if (null === $viewName) {
             $viewName = $this->container->getParameter('white_october_pagerfanta.default_view');
         }
 
-        $router = $this->container->get('router');
+        $routeGenerator = $options['routeGenerator'];
 
-        if (null === $options['routeName']) {
-            $request = $this->container->get('request');
+        if (null === $options['routeGenerator']) {
+            $router = $this->container->get('router');
 
-            $options['routeName'] = $request->attributes->get('_route');
-            if ('_internal' === $options['routeName']) {
-                throw new \Exception('PagerfantaBundle can not guess the route when used in a subrequest');
+            if (null === $options['routeName']) {
+                $request = $this->container->get('request');
+
+                $options['routeName'] = $request->attributes->get('_route');
+                if ('_internal' === $options['routeName']) {
+                    throw new \Exception('PagerfantaBundle can not guess the route when used in a subrequest');
+                }
+
+                $options['routeParams'] = array_merge($request->query->all(), $request->attributes->get('_route_params'));
             }
-                        
-            $options['routeParams'] = array_merge($request->query->all(), $request->attributes->get('_route_params'));
-        }
 
-        $routeName = $options['routeName'];
-        $routeParams = $options['routeParams'];
-        $pagePropertyPath = new PropertyPath($options['pageParameter']);
-        $routeGenerator = function($page) use($router, $routeName, $routeParams, $pagePropertyPath) {
-            $propertyAccessor = PropertyAccess::getPropertyAccessor();
-            $propertyAccessor->setValue($routeParams, $pagePropertyPath, $page);
-            return $router->generate($routeName, $routeParams);
-        };
+            $routeName = $options['routeName'];
+            $routeParams = $options['routeParams'];
+            $pagePropertyPath = new PropertyPath($options['pageParameter']);
+            $routeGenerator = function ($page) use ($router, $routeName, $routeParams, $pagePropertyPath) {
+                $propertyAccessor = PropertyAccess::getPropertyAccessor();
+                $propertyAccessor->setValue($routeParams, $pagePropertyPath, $page);
+
+                return $router->generate($routeName, $routeParams);
+            };
+        }
 
         return $this->container->get('white_october_pagerfanta.view_factory')->get($viewName)->render($pagerfanta, $routeGenerator, $options);
     }


### PR DESCRIPTION
In some usecases may be needed custom route generator.
For example, when we have multiple routes on the same action or for custom logic for URL generation.
