### PR TITLE
Fixed issue with reading routeParams from options

### DIFF
--- a/Twig/PagerfantaExtension.php
+++ b/Twig/PagerfantaExtension.php
@@ -114,8 +114,15 @@ class PagerfantaExtension extends \Twig_Extension
             if ('_internal' === $options['routeName']) {
                 throw new \Exception('PagerfantaBundle can not guess the route when used in a subrequest');
             }
+            
+            // make sure we read the route parameters from the passed option array            
+            $defaultRouteParams = array_merge($request->query->all(), $request->attributes->get('_route_params'));
 
-            $options['routeParams'] = array_merge($request->query->all(), $request->attributes->get('_route_params'));
+            if (array_key_exists('routeParams', $options)) {
+                $options['routeParams'] = array_merge($defaultRouteParams, $options['routeParams']);
+            } else {
+                $options['routeParams'] = $defaultRouteParams;
+            }   
         }
 
         $routeName = $options['routeName'];


### PR DESCRIPTION
When providing routeParams in options such as this:

``` php
{{ pagerfanta(pagerfanta, 'twitter_bootstrap', {'routeParams': {'keyword': keyword, 'platform': platform}}) }}
```

The options['routeParams'] would be overridden if manually specified. 

This pull request fixes that issue.
