### PR TITLE
replace getPropertyAccessor with createPropertyAccessor

### DIFF
--- a/Twig/PagerfantaExtension.php
+++ b/Twig/PagerfantaExtension.php
@@ -130,7 +130,7 @@ class PagerfantaExtension extends \Twig_Extension
         $pagePropertyPath = new PropertyPath($options['pageParameter']);
 
         return function($page) use($router, $routeName, $routeParams, $pagePropertyPath) {
-            $propertyAccessor = PropertyAccess::getPropertyAccessor();
+            $propertyAccessor = PropertyAccess::createPropertyAccessor();
             $propertyAccessor->setValue($routeParams, $pagePropertyPath, $page);
 
             return $router->generate($routeName, $routeParams);


### PR DESCRIPTION
getPropertyAccessor was deprecated in Symfony 2.3. This commit solves
a deprecation warning that shows up in Symfony 2.7.