### PR TITLE
[Twig] Fixed missing query string encoding

### DIFF
--- a/Twig/PagerfantaExtension.php
+++ b/Twig/PagerfantaExtension.php
@@ -133,7 +133,21 @@ class PagerfantaExtension extends \Twig_Extension
             $propertyAccessor = PropertyAccess::createPropertyAccessor();
             $propertyAccessor->setValue($routeParams, $pagePropertyPath, $page);
 
-            return $router->generate($routeName, $routeParams);
+            $url = $router->generate($routeName, $routeParams);
+
+            $parsedUrl = parse_url($url);
+
+            if (array_key_exists('query', $parsedUrl)) {
+                // encode query parameters
+                
+                $path = array_key_exists('path', $parsedUrl) ? $parsedUrl['path'] : '';
+                
+                parse_str($parsedUrl['query'], $queryParams);
+
+                $url = sprintf('%s?%s', $path, http_build_query($queryParams));
+            }
+            
+            return $url;
         };
     }
 


### PR DESCRIPTION
Query parameters were not being encoded. 

Reproduce: have your current url contain a parameter with a forward slash. E.g. something like `/foo?param1=/this/is/weird/`. As long as it's not a route parameter. 

Appearantly the twig extension assumes the URL (`_route`) in the current request is always safe for templates, but that is not the case.

