### PR TITLE
Switch the Twig integration to use non-deprecated APIs

### DIFF
--- a/Twig/PagerfantaExtension.php
+++ b/Twig/PagerfantaExtension.php
@@ -41,8 +41,8 @@ class PagerfantaExtension extends \Twig_Extension
     public function getFunctions()
     {
         return array(
-            'pagerfanta' => new \Twig_Function_Method($this, 'renderPagerfanta', array('is_safe' => array('html'))),
-            'pagerfanta_page_url' => new \Twig_Function_Method($this, 'getPageUrl')
+            new \Twig_SimpleFunction('pagerfanta', array($this, 'renderPagerfanta'), array('is_safe' => array('html'))),
+            new \Twig_SimpleFunction('pagerfanta_page_url', array($this, 'getPageUrl')),
         );
     }
 


### PR DESCRIPTION
This makes the bundle compatible with Twig 2.0 and avoids the deprecation warning in 1.21+

This requires Twig 1.12+, but Symfony already has this min requirement on Twig since 2.3.0
