### PR TITLE
Improve the travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,29 @@ language: php
 php:
   - 5.3
   - 5.4
+  - 5.5
+  - 5.6
+  - 7.0
+  - hhvm
 
-env:
-  - SYMFONY_VERSION=2.2.*
-  - SYMFONY_VERSION=2.3.*
+matrix:
+  include:
+    # Force testing against LTS versions
+    - php: 5.6
+      env: SYMFONY_VERSION=2.3.*
+    - php: 5.6
+      env: SYMFONY_VERSION=2.7.*
 
-before_script:
-  - composer require symfony/symfony:${SYMFONY_VERSION} --dev --no-update
-  - composer install --dev
+sudo: false
+
+cache:
+  directories:
+    - $HOME/.composer/cache/files
+
+before_install:
+  - if [ "$SYMFONY_VERSION" != "" ]; then composer require --dev --no-update symfony/symfony=$SYMFONY_VERSION; fi
+
+install:
+  - composer install
 
 script: php tests.php

--- a/TestsProject/src/WhiteOctober/PagerfantaTestBundle/Controller/PagerfantaController.php
+++ b/TestsProject/src/WhiteOctober/PagerfantaTestBundle/Controller/PagerfantaController.php
@@ -31,22 +31,16 @@ class PagerfantaController extends Controller
 
     public function defaultTranslatedViewAction()
     {
-        $this->setLocale('es');
-
         return $this->renderPagerfanta('defaultTranslatedView');
     }
 
     public function twitterBootstrapTranslatedViewAction()
     {
-        $this->setLocale('es');
-
         return $this->renderPagerfanta('twitterBootstrapTranslatedView');
     }
 
     public function twitterBootstrap3TranslatedViewAction()
     {
-        $this->setLocale('es');
-
         return $this->renderPagerfanta('twitterBootstrap3TranslatedView');
     }
 
@@ -54,7 +48,6 @@ class PagerfantaController extends Controller
     {
         return $this->renderPagerfanta('myView1');
     }
-
 
     public function viewWithRouteParamsAction($test = null)
     {
@@ -102,10 +95,5 @@ class PagerfantaController extends Controller
         $results = range(1, $nbResults);
 
         return new FixedAdapter($nbResults, $results);
-    }
-
-    private function setLocale($locale)
-    {
-        $this->getRequest()->setLocale($locale);
     }
 }

--- a/TestsProject/src/WhiteOctober/PagerfantaTestBundle/Resources/config/routing.yml
+++ b/TestsProject/src/WhiteOctober/PagerfantaTestBundle/Resources/config/routing.yml
@@ -21,15 +21,15 @@ pagerfanta_view_with_route_params:
 
 pagerfanta_default_translated_view:
     path:      /pagerfanta/default-translated-view
-    defaults:  { _controller: WhiteOctoberPagerfantaTestBundle:Pagerfanta:defaultTranslatedView }
+    defaults:  { _controller: WhiteOctoberPagerfantaTestBundle:Pagerfanta:defaultTranslatedView, _locale: es }
 
 pagerfanta_twitter_bootstrap_translated_view:
     path:      /pagerfanta/twitter-bootstrap-translated-view
-    defaults:  { _controller: WhiteOctoberPagerfantaTestBundle:Pagerfanta:twitterBootstrapTranslatedView }
+    defaults:  { _controller: WhiteOctoberPagerfantaTestBundle:Pagerfanta:twitterBootstrapTranslatedView, _locale: es }
 
 pagerfanta_twitter_bootstrap3_translated_view:
     path:      /pagerfanta/twitter-bootstrap3-translated-view
-    defaults:  { _controller: WhiteOctoberPagerfantaTestBundle:Pagerfanta:twitterBootstrap3TranslatedView }
+    defaults:  { _controller: WhiteOctoberPagerfantaTestBundle:Pagerfanta:twitterBootstrap3TranslatedView, _locale: es }
 
 pagerfanta_my_view_1:
     path:      /pagerfanta/my-view-1


### PR DESCRIPTION
- test against more PHP versions, including PHP 7 and HHVM
- remove testing against Symfony 2.2 as it is not supported by the bundle anymore
- add testing against newer versions of symfony than 2.3
- switch to the faster container-based infrastructure on Travis
- persist the composer cache between builds