### PR TITLE
Remove usage of the deprecated target-dir feature

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,9 +21,8 @@
         "phpunit/phpunit": "~3.7"
     },
     "autoload": {
-        "psr-0": { "WhiteOctober\\PagerfantaBundle": "" }
+        "psr-4": { "WhiteOctober\\PagerfantaBundle\\": "" }
     },
-    "target-dir": "WhiteOctober/PagerfantaBundle",
     "extra": {
         "branch-alias": {
             "dev-master": "1.0.x-dev"


### PR DESCRIPTION
target-dir was a setting introduced in Composer to support some repo structures suited for PSR-4 before PSR-4 was standardized. This feature is considered deprecated in Composer and PSR-4 should be used.