### PR TITLE
Fix a memory size exhausted error for some PHP versions in Travis CI

### DIFF
--- a/.travis.php.ini
+++ b/.travis.php.ini
@@ -1,0 +1,1 @@
+memory_limit = -1

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,8 @@ cache:
     - $HOME/.composer/cache/files
 
 before_install:
+  - if [[ "$TRAVIS_PHP_VERSION" != "hhvm" ]]; then phpenv config-rm xdebug.ini; fi
+  - if [[ "$TRAVIS_PHP_VERSION" != "hhvm" ]]; then phpenv config-add .travis.php.ini; fi
   - composer self-update
   - if [ "$SYMFONY_VERSION" != "" ]; then composer require --dev --no-update symfony/symfony=$SYMFONY_VERSION; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ cache:
     - $HOME/.composer/cache/files
 
 before_install:
+  # NOTE: The HHVM doesn't support phpenv
   - if [[ "$TRAVIS_PHP_VERSION" != "hhvm" ]]; then phpenv config-rm xdebug.ini; fi
   - if [[ "$TRAVIS_PHP_VERSION" != "hhvm" ]]; then phpenv config-add .travis.php.ini; fi
   - composer self-update


### PR DESCRIPTION
However, this does not solve the problem with `Allowed memory size exhausted` in Travis...