### PR TITLE
Make first page param configurable

### DIFF
--- a/TestsProject/src/WhiteOctober/PagerfantaTestBundle/Controller/PagerfantaController.php
+++ b/TestsProject/src/WhiteOctober/PagerfantaTestBundle/Controller/PagerfantaController.php
@@ -29,6 +29,11 @@ class PagerfantaController extends Controller
         return $this->renderPagerfanta('viewWithOptions');
     }
 
+    public function viewWithFirstPageParamAction(Request $request)
+    {
+        return $this->defaultWithRequestAction($request, 'viewWithFirstPageParam');
+    }
+
     public function defaultTranslatedViewAction()
     {
         return $this->renderPagerfanta('defaultTranslatedView');
@@ -54,9 +59,9 @@ class PagerfantaController extends Controller
         return $this->renderPagerfanta('viewWithRouteParams');
     }
 
-    public function defaultWithRequestAction(Request $request)
+    public function defaultWithRequestAction(Request $request, $name = 'defaultView')
     {
-        $template = $this->buildTemplateName('defaultView');
+        $template = $this->buildTemplateName($name);
         $pagerfanta = $this->createPagerfanta();
         $pagerfanta->setMaxPerPage($request->query->get('maxPerPage', 10));
         $pagerfanta->setCurrentPage($request->query->get('currentPage', 1));

--- a/TestsProject/src/WhiteOctober/PagerfantaTestBundle/Resources/config/routing.yml
+++ b/TestsProject/src/WhiteOctober/PagerfantaTestBundle/Resources/config/routing.yml
@@ -38,3 +38,7 @@ pagerfanta_my_view_1:
 pagerfanta_correct_view:
     path:      /pagerfanta/custom-page
     defaults:  { _controller: WhiteOctoberPagerfantaTestBundle:Pagerfanta:defaultWithRequest }
+
+pagerfanta_view_with_first_page_param:
+    path:      /pagerfanta/view-with-first-page-param
+    defaults:  { _controller: WhiteOctoberPagerfantaTestBundle:Pagerfanta:viewWithFirstPageParam }

--- a/TestsProject/src/WhiteOctober/PagerfantaTestBundle/Resources/views/Pagerfanta/viewWithFirstPageParam.html.twig
+++ b/TestsProject/src/WhiteOctober/PagerfantaTestBundle/Resources/views/Pagerfanta/viewWithFirstPageParam.html.twig
@@ -1,0 +1,1 @@
+{{ pagerfanta(pagerfanta, 'default', {'omitFirstPage': false}) }}

--- a/TestsProject/src/WhiteOctober/PagerfantaTestBundle/Tests/Controller/PagerfantaControllerTest.php
+++ b/TestsProject/src/WhiteOctober/PagerfantaTestBundle/Tests/Controller/PagerfantaControllerTest.php
@@ -215,6 +215,27 @@ EOF
     /**
      * @test
      */
+    public function testFirstPageParam()
+    {
+        $this->assertView('view-with-first-page-param?currentPage=2', <<<EOF
+<nav>
+    <a href="/pagerfanta/view-with-first-page-param?currentPage=2&page=1">Previous</a>
+    <a href="/pagerfanta/view-with-first-page-param?currentPage=2&page=1">1</a>
+    <span class="current">2</span>
+    <a href="/pagerfanta/view-with-first-page-param?currentPage=2&page=3">3</a>
+    <a href="/pagerfanta/view-with-first-page-param?currentPage=2&page=4">4</a>
+    <a href="/pagerfanta/view-with-first-page-param?currentPage=2&page=5">5</a>
+    <span class="dots">...</span>
+    <a href="/pagerfanta/view-with-first-page-param?currentPage=2&page=10">10</a>
+    <a href="/pagerfanta/view-with-first-page-param?currentPage=2&page=3">Next</a>
+</nav>
+EOF
+        );
+    }
+
+    /**
+     * @test
+     */
     public function testWrongMaxPerPageExceptionWithNoneStrategy()
     {
         $client = static::createClient();

--- a/Twig/PagerfantaExtension.php
+++ b/Twig/PagerfantaExtension.php
@@ -103,6 +103,7 @@ class PagerfantaExtension extends \Twig_Extension
                 'routeName'     => null,
                 'routeParams'   => array(),
                 'pageParameter' => '[page]',
+                'omitFirstPage' => true
             ), $options);
 
         $router = $this->container->get('router');
@@ -133,13 +134,15 @@ class PagerfantaExtension extends \Twig_Extension
         $routeName = $options['routeName'];
         $routeParams = $options['routeParams'];
         $pagePropertyPath = new PropertyPath($options['pageParameter']);
+        $omitFirstPage = $options['omitFirstPage'];
 
-        return function($page) use($router, $routeName, $routeParams, $pagePropertyPath) {
+        return function($page) use($router, $routeName, $routeParams, $pagePropertyPath, $omitFirstPage) {
             $propertyAccessor = PropertyAccess::createPropertyAccessor();
-            $propertyAccessor->setValue($routeParams, $pagePropertyPath, $page);
-
-            $pageParam = $page > 1 ? $page : null;
-            $propertyAccessor->setValue($routeParams, $pagePropertyPath, $pageParam);
+            if($omitFirstPage){
+                $propertyAccessor->setValue($routeParams, $pagePropertyPath, $page > 1 ? $page : null);
+            } else {
+                $propertyAccessor->setValue($routeParams, $pagePropertyPath, $page);
+            }
 
             return $router->generate($routeName, $routeParams);
         };


### PR DESCRIPTION
Due to the change in #131, it is no longer possible to return to page 1 when you save the page in the session (and you only update it when the `page` parameter is available in the URL). 

This can have several use cases and is in my opinion better for backwards compatibility. 

By simply setting the option `omitFirstPage` to `false` in your paginator call, you can get the 'old' behavior back.