### PR TITLE
improve omitFirstPage

### DIFF
--- a/Twig/PagerfantaExtension.php
+++ b/Twig/PagerfantaExtension.php
@@ -138,9 +138,8 @@ class PagerfantaExtension extends \Twig_Extension
 
         return function($page) use($router, $routeName, $routeParams, $pagePropertyPath, $omitFirstPage) {
             $propertyAccessor = PropertyAccess::createPropertyAccessor();
-            if($omitFirstPage){
-                $propertyAccessor->setValue($routeParams, $pagePropertyPath, $page > 1 ? $page : null);
-            } else {
+            // don't set the page parameter if it is the first page and the omitFirstPage flag is true
+            if(!$omitFirstPage || $page > 1 ){
                 $propertyAccessor->setValue($routeParams, $pagePropertyPath, $page);
             }
 


### PR DESCRIPTION
instead of setting the page parameter to null don't set it at all if omitFirstPage is set to true and page is first page. Otherwise some routers may append a questionmark at the end of the url even if there are no other parameters

I'm not quite sure if this is a general problem with a lot of routers but at least the `ez_urlalias` router of the ezplatform cms does this.