### PR TITLE
Travis updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ php:
   - 5.5
   - 5.6
   - 7.0
-  - hhvm
 
 matrix:
   include:
@@ -29,7 +28,7 @@ cache:
 before_install:
   - composer self-update
   - if [ "$SYMFONY_VERSION" != "" ]; then composer require --dev --no-update symfony/symfony=$SYMFONY_VERSION; fi
-  - if [[ $TRAVIS_PHP_VERSION != hhvm ]]; then INI_FILE=~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini; else INI_FILE=/etc/hhvm/php.ini; fi;
+  - INI_FILE=~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini;
   - echo memory_limit = -1 >> $INI_FILE
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: php
 
+dist: trusty
+
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 5.6
@@ -9,6 +10,9 @@ php:
 
 matrix:
   include:
+    # PHP 5.3 doesn't install on Trusty on Travis: https://github.com/travis-ci/travis-ci/issues/8219
+    - php: 5.3
+      dist: precise
     # Force testing against LTS versions
     - php: 5.6
       env: SYMFONY_VERSION=2.3.*


### PR DESCRIPTION
* Remove HHVM from Travis build - fixes #166
* Switch to Trusty (14.04) on Travis but keep 5.3 on Precise (12.04)

