### PR TITLE
Remove deprecations in PagerfantaExtension

### DIFF
--- a/DependencyInjection/WhiteOctoberPagerfantaExtension.php
+++ b/DependencyInjection/WhiteOctoberPagerfantaExtension.php
@@ -14,6 +14,7 @@ namespace WhiteOctober\PagerfantaBundle\DependencyInjection;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
@@ -49,6 +50,16 @@ class WhiteOctoberPagerfantaExtension extends Extension
         if ($config['exceptions_strategy']['not_valid_current_page'] == Configuration::EXCEPTION_STRATEGY_TO_HTTP_NOT_FOUND) {
             $convertListener = $container->getDefinition('pagerfanta.convert_not_valid_current_page_to_not_found_listener');
             $convertListener->addTag('kernel.event_subscriber');
+        }
+
+        // BC layer to inject the 'request' service when RequestStack is unavailable
+        if (!class_exists('Symfony\\Component\\HttpFoundation\\RequestStack')) {
+            $container
+                ->getDefinition('twig.extension.pagerfanta')
+                ->addMethodCall('setRequest', array(
+                    new Reference('request', ContainerInterface::NULL_ON_INVALID_REFERENCE, false),
+                ))
+            ;
         }
     }
 }

--- a/DependencyInjection/WhiteOctoberPagerfantaExtension.php
+++ b/DependencyInjection/WhiteOctoberPagerfantaExtension.php
@@ -16,6 +16,7 @@ use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
+use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 /**

--- a/Resources/config/pagerfanta.xml
+++ b/Resources/config/pagerfanta.xml
@@ -74,7 +74,6 @@
             <argument type="service" id="white_october_pagerfanta.view_factory" />
             <argument type="service" id="router" />
             <argument type="service" id="request_stack" on-invalid="null" />
-            <argument type="service" id="request" on-invalid="null" />
         </service>
 
         <service id="pagerfanta.convert_not_valid_max_per_page_to_not_found_listener" class="WhiteOctober\PagerfantaBundle\EventListener\ConvertNotValidMaxPerPageToNotFoundListener">

--- a/Resources/config/pagerfanta.xml
+++ b/Resources/config/pagerfanta.xml
@@ -70,7 +70,11 @@
         <!-- Twig Extension -->
         <service id="twig.extension.pagerfanta" class="WhiteOctober\PagerfantaBundle\Twig\PagerfantaExtension" public="false">
             <tag name="twig.extension" />
-            <argument type="service" id="service_container" />
+            <argument>%white_october_pagerfanta.default_view%</argument>
+            <argument type="service" id="white_october_pagerfanta.view_factory" />
+            <argument type="service" id="router" />
+            <argument type="service" id="request_stack" on-invalid="null" />
+            <argument type="service" id="request" on-invalid="null" />
         </service>
 
         <service id="pagerfanta.convert_not_valid_max_per_page_to_not_found_listener" class="WhiteOctober\PagerfantaBundle\EventListener\ConvertNotValidMaxPerPageToNotFoundListener">

--- a/Twig/PagerfantaExtension.php
+++ b/Twig/PagerfantaExtension.php
@@ -38,7 +38,6 @@ class PagerfantaExtension extends \Twig_Extension
         $this->viewFactory = $viewFactory;
         $this->router = $router;
         $this->requestStack = $requestStack;
-        $this->request = $request;
     }
 
     /**

--- a/Twig/PagerfantaExtension.php
+++ b/Twig/PagerfantaExtension.php
@@ -13,7 +13,7 @@ namespace WhiteOctober\PagerfantaBundle\Twig;
 
 use Pagerfanta\PagerfantaInterface;
 use Pagerfanta\View\ViewFactory;
-use Symfony\Component\BrowserKit\Request;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyPath;

--- a/Twig/PagerfantaExtension.php
+++ b/Twig/PagerfantaExtension.php
@@ -32,7 +32,7 @@ class PagerfantaExtension extends \Twig_Extension
     private $requestStack;
     private $request;
 
-    public function __construct($defaultView, ViewFactory $viewFactory, RouterInterface $router, RequestStack $requestStack)
+    public function __construct($defaultView, ViewFactory $viewFactory, RouterInterface $router, RequestStack $requestStack = null)
     {
         $this->defaultView = $defaultView;
         $this->viewFactory = $viewFactory;

--- a/Twig/PagerfantaExtension.php
+++ b/Twig/PagerfantaExtension.php
@@ -17,7 +17,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyPath;
-use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 /**
  * PagerfantaExtension.
@@ -32,7 +32,7 @@ class PagerfantaExtension extends \Twig_Extension
     private $requestStack;
     private $request;
 
-    public function __construct($defaultView, ViewFactory $viewFactory, RouterInterface $router, RequestStack $requestStack = null)
+    public function __construct($defaultView, ViewFactory $viewFactory, UrlGeneratorInterface $router, RequestStack $requestStack = null)
     {
         $this->defaultView = $defaultView;
         $this->viewFactory = $viewFactory;

--- a/Twig/PagerfantaExtension.php
+++ b/Twig/PagerfantaExtension.php
@@ -32,7 +32,7 @@ class PagerfantaExtension extends \Twig_Extension
     private $requestStack;
     private $request;
 
-    public function __construct($defaultView, ViewFactory $viewFactory, RouterInterface $router, RequestStack $requestStack, Request $request)
+    public function __construct($defaultView, ViewFactory $viewFactory, RouterInterface $router, RequestStack $requestStack)
     {
         $this->defaultView = $defaultView;
         $this->viewFactory = $viewFactory;
@@ -117,12 +117,7 @@ class PagerfantaExtension extends \Twig_Extension
         $router = $this->router;
 
         if (null === $options['routeName']) {
-            if (null !== $this->requestStack) {
-                $request = $this->requestStack->getCurrentRequest();
-            } else {
-                // Symfony 2.3 compatibility
-                $request = $this->request;
-            }
+            $request = $this->getRequest();
 
             $options['routeName'] = $request->attributes->get('_route');
             if ('_internal' === $options['routeName']) {
@@ -153,6 +148,23 @@ class PagerfantaExtension extends \Twig_Extension
 
             return $router->generate($routeName, $routeParams);
         };
+    }
+
+    public function setRequest(Request $request = null)
+    {
+        $this->request = $request;
+    }
+
+    /**
+     * @return Request|null
+     */
+    private function getRequest()
+    {
+        if ($this->requestStack && $request = $this->requestStack->getCurrentRequest()) {
+            return $request;
+        }
+
+        return $this->request;
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -12,13 +12,13 @@
     ],
     "require": {
         "symfony/framework-bundle": "~2.3|~3.0|~4.0",
-        "symfony/twig-bundle": "~2.3|~3.0",
+        "symfony/twig-bundle": "~2.3|~3.0|~4.0",
         "symfony/property-access": "~2.3|~3.0",
         "pagerfanta/pagerfanta": "1.0.*"
     },
     "require-dev": {
         "symfony/symfony": "~2.3|~3.0|~4.0",
-        "phpunit/phpunit": "~3.7"
+        "phpunit/phpunit": "~3.7|~4.0"
     },
     "autoload": {
         "psr-4": { "WhiteOctober\\PagerfantaBundle\\": "" }

--- a/composer.json
+++ b/composer.json
@@ -11,13 +11,13 @@
         }
     ],
     "require": {
-        "symfony/framework-bundle": "~2.3|~3.0",
+        "symfony/framework-bundle": "~2.3|~3.0|~4.0",
         "symfony/twig-bundle": "~2.3|~3.0",
         "symfony/property-access": "~2.3|~3.0",
         "pagerfanta/pagerfanta": "1.0.*"
     },
     "require-dev": {
-        "symfony/symfony": "~2.3|~3.0",
+        "symfony/symfony": "~2.3|~3.0|~4.0",
         "phpunit/phpunit": "~3.7"
     },
     "autoload": {


### PR DESCRIPTION
While upgrading the Symfony Demo app to Symfony 3.4/4.0, we found a deprecation in this bundle (see https://github.com/symfony/symfony-demo/pull/673).

This pull request tries to fix it.