### PR TITLE
Allow >= 1.1.0 & 2.x for Pagerfanta

### DIFF
--- a/Tests/View/DefaultTranslatedViewTest.php
+++ b/Tests/View/DefaultTranslatedViewTest.php
@@ -25,7 +25,7 @@ class DefaultTranslatedViewTest extends TranslatedViewTest
 
     protected function previousMessageOption()
     {
-        return 'previous_message';
+        return 'prev_message';
     }
 
     protected function nextMessageOption()

--- a/TestsProject/app/config_test.yml
+++ b/TestsProject/app/config_test.yml
@@ -20,6 +20,6 @@ services:
         class: Pagerfanta\View\OptionableView
         arguments:
             - '@pagerfanta.view.default'
-            - { proximity: 2, previous_message: Anterior, next_message: Siguiente }
+            - { proximity: 2, prev_message: Anterior, next_message: Siguiente }
         public: false
         tags: [{ name: pagerfanta.view, alias: my_view_1 }]

--- a/View/DefaultTranslatedView.php
+++ b/View/DefaultTranslatedView.php
@@ -22,7 +22,7 @@ class DefaultTranslatedView extends TranslatedView
 {
     protected function previousMessageOption()
     {
-        return 'previous_message';
+        return 'prev_message';
     }
 
     protected function nextMessageOption()

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": ">=5.3",
-        "pagerfanta/pagerfanta": "1.0.*",
+        "pagerfanta/pagerfanta": "^1.0.0",
         "symfony/framework-bundle": "~2.3|~3.0|~4.0",
         "symfony/property-access": "~2.3|~3.0|~4.0",
         "symfony/twig-bundle": "~2.3|~3.0|~4.0"

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": ">=5.3",
-        "pagerfanta/pagerfanta": "^1.0.0|^2.0.0",
+        "pagerfanta/pagerfanta": "^1.1.0|^2.0.0",
         "symfony/framework-bundle": "~2.3|~3.0|~4.0",
         "symfony/property-access": "~2.3|~3.0|~4.0",
         "symfony/twig-bundle": "~2.3|~3.0|~4.0"

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": ">=5.3",
-        "pagerfanta/pagerfanta": "^1.0.0",
+        "pagerfanta/pagerfanta": "^1.0.0|^2.0.0",
         "symfony/framework-bundle": "~2.3|~3.0|~4.0",
         "symfony/property-access": "~2.3|~3.0|~4.0",
         "symfony/twig-bundle": "~2.3|~3.0|~4.0"


### PR DESCRIPTION
The latest 1.x release is https://github.com/whiteoctober/Pagerfanta/releases/tag/v1.1.0, which the previous constraint wouldn't have allowed.