### PR TITLE
Document adding to config/bundles.php

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ Installation
 php composer.phar require white-october/pagerfanta-bundle
 ```
 
-2) Then add the WhiteOctoberPagerfantaBundle to your application kernel:
+2) Then add the WhiteOctoberPagerfantaBundle to your application:
+
+In Symfony < 4:
 
 ```php
 // app/AppKernel.php
@@ -35,6 +37,19 @@ public function registerBundles()
     );
 }
 ```
+
+In Symfony 4:
+
+```php
+// config/bundles.php
+return [
+    // ...
+    WhiteOctober\PagerfantaBundle\WhiteOctoberPagerfantaBundle::class => ['all' => true],
+    // ...
+];
+```
+
+(This project is not yet configured with Symfony Flex, so this change to `config/bundles.php` won't be done automatically.)
 
 3) Configure and use things!
 


### PR DESCRIPTION
In Symfony 4, bundles go in `config/bundles.php`, not `app/AppKernel.php`: https://symfony.com/doc/current/bundles.html

This PR updates the documentation to reflect that.

Fixes https://github.com/whiteoctober/WhiteOctoberPagerfantaBundle/issues/197.