### PR TITLE
Explicitly require Symfony translator

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
         "pagerfanta/pagerfanta": "^1.1.0|^2.0.0",
         "symfony/framework-bundle": "~2.3|~3.0|~4.0",
         "symfony/property-access": "~2.3|~3.0|~4.0",
+        "symfony/translation": "~2.3|~3.0|~4.0",
         "symfony/twig-bundle": "~2.3|~3.0|~4.0"
     },
     "require-dev": {


### PR DESCRIPTION
I guess that's why the build of the Symfony Flex recipe is failing: https://travis-ci.org/symfony/recipes-contrib/jobs/412052804