### PR TITLE
Add swahili translation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ php:
   - 7.0
   - 7.1
   - 7.2
+  - 7.3
 
 matrix:
   fast_finish: true
@@ -31,6 +32,8 @@ matrix:
     - php: 5.6
       env: SYMFONY_VERSION=3.0.*
     - php: 7.2
+      env: SYMFONY_VERSION=4.0.*
+    - php: 7.3
       env: SYMFONY_VERSION=4.0.*
 
 cache:

--- a/Resources/translations/pagerfanta.sw.xliff
+++ b/Resources/translations/pagerfanta.sw.xliff
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" target-language="sw" datatype="plaintext" original="file.ext">
+        <body>
+            <trans-unit id="1">
+                <source>previous</source>
+                <target>Nyuma</target>
+            </trans-unit>
+            <trans-unit id="2">
+                <source>next</source>
+                <target>Mbele</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>


### PR DESCRIPTION
Add Swahili Translation, Swahili  is a lingua franca of the African Great Lakes region and other parts of eastern and south-eastern Africa, including Tanzania, Kenya, Uganda, Rwanda, Burundi, Mozambique, and the Democratic Republic of the Congo (DRC).

This will greatly benefit numerous developers that want to build multi-lingual websites that support the Swahili Language.