### PR TITLE
Update README regarding Symfony 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,18 +38,7 @@ public function registerBundles()
 }
 ```
 
-In Symfony 4:
-
-```php
-// config/bundles.php
-return [
-    // ...
-    WhiteOctober\PagerfantaBundle\WhiteOctoberPagerfantaBundle::class => ['all' => true],
-    // ...
-];
-```
-
-(This project is not yet configured with Symfony Flex, so this change to `config/bundles.php` won't be done automatically.)
+In Symfony 4 with Symfony Flex this will be done automatically for you.
 
 3) Configure and use things!
 


### PR DESCRIPTION
I just installed the bundle with Symfony 4.2 and I noticed that I didn't have to update the bundle.php - it was done automatically via auto-generated recipe. So this PR is to update the README accordingly.

```
Symfony operations: 1 recipe (7b6495c18d05b6f8c45996a88d5ccdc5)
  - Configuring white-october/pagerfanta-bundle (>=v1.2.3): From auto-generated recipe
```