### PR TITLE
Switch to namespaced Twig classes

### DIFF
--- a/Twig/PagerfantaExtension.php
+++ b/Twig/PagerfantaExtension.php
@@ -18,13 +18,15 @@ use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyPath;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
 
 /**
  * PagerfantaExtension.
  *
  * @author Pablo Díez <pablodip@gmail.com>
  */
-class PagerfantaExtension extends \Twig_Extension
+class PagerfantaExtension extends AbstractExtension
 {
     private $defaultView;
     private $viewFactory;
@@ -46,8 +48,8 @@ class PagerfantaExtension extends \Twig_Extension
     public function getFunctions()
     {
         return array(
-            new \Twig_SimpleFunction('pagerfanta', array($this, 'renderPagerfanta'), array('is_safe' => array('html'))),
-            new \Twig_SimpleFunction('pagerfanta_page_url', array($this, 'getPageUrl')),
+            new TwigFunction('pagerfanta', array($this, 'renderPagerfanta'), array('is_safe' => array('html'))),
+            new TwigFunction('pagerfanta_page_url', array($this, 'getPageUrl')),
         );
     }
 

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3",
+        "php": ">=5.3.3",
         "pagerfanta/pagerfanta": "^1.1.0|^2.0.0",
         "symfony/framework-bundle": "~2.3|~3.0|~4.0",
         "symfony/property-access": "~2.3|~3.0|~4.0",
@@ -21,6 +21,9 @@
     "require-dev": {
         "symfony/symfony": "~2.3|~3.0|~4.0",
         "phpunit/phpunit": "~3.7|~4.0|^5.0"
+    },
+    "conflict": {
+        "twig/twig": "<1.34"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Hello,

I think it's due switching to Twig's namespaced classes in order to support next versions of Twig/Symfony.

https://symfony.com/blog/new-in-twig-namespaced-classes