### PR TITLE
Expand Twig version conflict

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "phpunit/phpunit": "~3.7|~4.0|^5.0"
     },
     "conflict": {
-        "twig/twig": "<1.34"
+        "twig/twig": "<1.34|>=2.0,<2.4"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Namespaced classes were introduced into Twig in 1.34 and 2.4, so the 2.0 through 2.3 releases also need to be flagged.