### PR TITLE
Replace the use of deprecated get/setException() by get/setThrowable()

### DIFF
--- a/EventListener/ConvertNotValidCurrentPageToNotFoundListener.php
+++ b/EventListener/ConvertNotValidCurrentPageToNotFoundListener.php
@@ -14,8 +14,21 @@ class ConvertNotValidCurrentPageToNotFoundListener implements EventSubscriberInt
      */
     public function onException(GetResponseForExceptionEvent $event)
     {
-        if ($event->getException() instanceof NotValidCurrentPageException) {
-            $event->setException(new NotFoundHttpException('Page Not Found', $event->getException()));
+        if (method_exists($event, 'getThrowable')) {
+            $throwable = $event->getThrowable();
+        } else {
+            // Support for Symfony 4.3 and before
+            $throwable = $event->getException();
+        }
+
+        if ($throwable instanceof NotValidCurrentPageException) {
+            $notFoundHttpException = new NotFoundHttpException('Page Not Found', $throwable);
+            if (method_exists($event, 'setThrowable')) {
+                $event->setThrowable($notFoundHttpException);
+            } else {
+                // Support for Symfony 4.3 and before
+                $event->setException($notFoundHttpException);
+            }
         }
     }
 

--- a/EventListener/ConvertNotValidMaxPerPageToNotFoundListener.php
+++ b/EventListener/ConvertNotValidMaxPerPageToNotFoundListener.php
@@ -14,8 +14,21 @@ class ConvertNotValidMaxPerPageToNotFoundListener implements EventSubscriberInte
      */
     public function onException(GetResponseForExceptionEvent $event)
     {
-        if ($event->getException() instanceof NotValidMaxPerPageException) {
-            $event->setException(new NotFoundHttpException('Page Not Found', $event->getException()));
+        if (method_exists($event, 'getThrowable')) {
+            $throwable = $event->getThrowable();
+        } else {
+            // Support for Symfony 4.3 and before
+            $throwable = $event->getException();
+        }
+
+        if ($throwable instanceof NotValidMaxPerPageException) {
+            $notFoundHttpException = new NotFoundHttpException('Page Not Found', $throwable);
+            if (method_exists($event, 'setThrowable')) {
+                $event->setThrowable($notFoundHttpException);
+            } else {
+                // Support for Symfony 4.3 and before
+                $event->setException($notFoundHttpException);
+            }
         }
     }
 


### PR DESCRIPTION
`getException()` and `setException()` on `GetResponseForExceptionEvent` are deprecated since Symfony 4.4.

This PR makes sure that `getThrowable()` and `setThrowable()` are called instead. We use `method_exists()` to check if these methods exists, and otherwise fallback to `getException()` and `setException()` to keep support for Symfony 4.3 and before.