### PR TITLE
Remove deprecation

### DIFF
--- a/EventListener/ConvertNotValidMaxPerPageToNotFoundListener.php
+++ b/EventListener/ConvertNotValidMaxPerPageToNotFoundListener.php
@@ -15,7 +15,7 @@ class ConvertNotValidMaxPerPageToNotFoundListener implements EventSubscriberInte
     public function onException(GetResponseForExceptionEvent $event)
     {
         if ($event->getException() instanceof NotValidMaxPerPageException) {
-            $event->setException(new NotFoundHttpException('Page Not Found', $event->getException()));
+            $event->setException(new NotFoundHttpException('Page Not Found', $event->getThrowable()));
         }
     }
 


### PR DESCRIPTION
User Deprecated: The "Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent::getException()" method is deprecated since Symfony 4.4, we need to use "getThrowable()" instead.